### PR TITLE
Micro addon support

### DIFF
--- a/lib/models/addons-factory.js
+++ b/lib/models/addons-factory.js
@@ -28,6 +28,7 @@ AddonsFactory.prototype.initializeAddons = function(addonPackages){
   var project     = this.project;
   var graph       = new DAG();
   var Addon      = require('../models/addon');
+  var MicroAddon = require('../models/micro-addon');
   var addonInfo, emberAddonConfig;
 
   debug('initializeAddons for: ', typeof addonParent.name === 'function' ? addonParent.name() : addonParent.name);
@@ -44,7 +45,8 @@ AddonsFactory.prototype.initializeAddons = function(addonPackages){
   graph.topsort(function (vertex) {
     var addonInfo = vertex.value;
     if (addonInfo) {
-      var AddonConstructor = Addon.lookup(addonInfo);
+      var isMicroAddon = addonInfo.pkg.keywords.indexOf('ember-micro-addon') > -1;
+      var AddonConstructor = isMicroAddon ? MicroAddon.lookup(addonInfo) : Addon.lookup(addonInfo);
       var addon = new AddonConstructor(addonParent, project);
       if (addon.initializeAddons) {
         addon.initializeAddons();

--- a/lib/models/micro-addon.js
+++ b/lib/models/micro-addon.js
@@ -9,6 +9,8 @@ var existsSync    = require('exists-sync');
 var Funnel        = require('broccoli-funnel');
 var assign        = require('lodash/object/assign');
 var SilentError   = require('silent-error');
+var mergeTrees    = require('broccoli-merge-trees');
+
 
 var Addon         = require('../models/addon');
 
@@ -77,7 +79,7 @@ var MicroAddon = Addon.extend({
     } else if (fileName === 'template.hbs') {
       return path.join('components', this.name + '.hbs');
     } else if (fileName === 'style.css') {
-      return path.join('addon/styles', this.name + '.css');
+      return path.join('addon', 'styles', this.name + '.css');
     } else if (fileName === 'helper.js') {
       return path.join('helpers', this.name + '.js');
     } else if (fileName === 'library.js') {
@@ -96,7 +98,7 @@ var MicroAddon = Addon.extend({
     @return {tree} A tree with properly mapped files.
   */
   treeForApp: function() {
-    var includedFiles = ['component.js', 'helper.js', 'library.js'];
+    var includedFiles = ['component.js', 'helper.js'];
 
     return this._buildTree(includedFiles);
   },
@@ -121,22 +123,52 @@ var MicroAddon = Addon.extend({
   },
 
   /**
-    Maps app-related files from their location in a ember-micro-addon structure
-    to their proper place in an ember-addon structure.
+    Maps style.css to addon/styles/[addon-name].css. At that point, treeForAddon
+    followed by the regular build process take over and style.css eventually
+    ends up being merged into the app's vendor.css.
 
-    Used by micro-components
-
-    We use treeForAddon to make use of automatic style merging for any .css
-    files placed in the addon/styles folder
-
-    @public
-    @method treeForAddon
+    @private
+    @method treeForAddonStyles
     @return {tree} A tree with properly mapped files.
   */
-  treeForAddon: function() {
+  _treeForAddonStyles: function() {
     var includedFiles = ['style.css'];
 
     return this._buildTree(includedFiles);
+  },
+
+  /**
+    Maps library.js to lib/library.js and outputs it to the addon folder. At
+    that point, treeForAddon and the regular build process take over and
+    library.js eventually becomes importable from
+    '[addon-name]/lib/[addon-name]'
+
+    @private
+    @method treeForAddonJs
+    @return {tree} A tree with properly mapped files.
+  */
+  _treeForAddonJs: function() {
+    var includedFiles = ['library.js'];
+
+    return this._buildTree(includedFiles);
+  },
+
+  /**
+    Generates an addon tree and an addon style tree using treeForAddonJs and
+    treeForAddonStyles, then merges them and returns the result.
+
+    @public
+    @method treeForAddon
+    @return {tree} Merged and compiled output of _treeForAddonJs and
+    _treeForAddonStyles
+  */
+  treeForAddon: function() {
+    var addonTree = this._treeForAddonJs();
+    var compiledAddonTree = this.compileAddon(addonTree);
+    var addonStylesTree = this._treeForAddonStyles();
+    var compiledStylesTree = this.compileStyles(addonStylesTree);
+
+    return mergeTrees([compiledAddonTree, compiledStylesTree]);
   }
 });
 

--- a/lib/models/micro-addon.js
+++ b/lib/models/micro-addon.js
@@ -1,0 +1,40 @@
+'use strict';
+
+var path = require('path');
+var Funnel = require('broccoli-funnel');
+var Addon  = require('../models/addon');
+
+Addon.prototype.buildTree = function(sourceTree, includedFiles) {
+  var addon = this;
+
+  return new Funnel(sourceTree, {
+    include: includedFiles,
+    getDestination: function(fileName) {
+      return addon.mapFile(fileName);
+    }
+  });
+};
+
+Addon.prototype.mapFile = function(fileName) {
+  if (fileName === 'component.js') {
+    return path.join('components', this.name + '.js');
+  } else if (fileName === 'template.hbs') {
+    return path.join('components', this.name + '.hbs');
+  } else if (fileName === 'style.css') {
+    return path.join('addon/styles', this.name + '.css');
+  } else if (fileName === 'helper.js') {
+    return path.join('helpers', this.name + '.js');
+  }
+};
+
+Addon.prototype.treeForApp = function() {
+  return this.buildTree(this.root, ['component.js', 'helper.js']);
+};
+
+Addon.prototype.treeForTemplates = function() {
+  return this.buildTreew(this.root, ['style.css']);
+};
+
+Addon.prototype.treeForAddon = function() {
+  return this.buildTree(this.root, ['template.hbs']);
+};

--- a/lib/models/micro-addon.js
+++ b/lib/models/micro-addon.js
@@ -12,14 +12,6 @@ var SilentError   = require('silent-error');
 
 var Addon         = require('../models/addon');
 
-function getExistingFiles(root, fileList) {
-  var filteredList = fileList.filter(function(file) {
-    return existsSync(path.join(root,file));
-  });
-
-  return filteredList;
-}
-
 /**
   Root class for a Micro Addon. If your Addon module exports an Object, this
   will be extended with that Object. If the addon module exports a constructor,
@@ -104,8 +96,7 @@ var MicroAddon = Addon.extend({
     @return {tree} A tree with properly mapped files.
   */
   treeForApp: function() {
-    var supportedFiles = ['component.js', 'helper.js', 'library.js'];
-    var includedFiles = getExistingFiles(this.root, supportedFiles);
+    var includedFiles = ['component.js', 'helper.js', 'library.js'];
 
     return this._buildTree(includedFiles);
   },
@@ -124,8 +115,7 @@ var MicroAddon = Addon.extend({
     @return {tree} A tree with properly mapped files.
   */
   treeForTemplates: function() {
-    var supportedFiles = ['template.hbs'];
-    var includedFiles = getExistingFiles(this.root, supportedFiles);
+    var includedFiles = ['template.hbs'];
 
     return this._buildTree(includedFiles);
   },
@@ -144,8 +134,7 @@ var MicroAddon = Addon.extend({
     @return {tree} A tree with properly mapped files.
   */
   treeForAddon: function() {
-    var supportedFiles = ['style.css'];
-    var includedFiles = getExistingFiles(this.root, supportedFiles);
+    var includedFiles = ['style.css'];
 
     return this._buildTree(includedFiles);
   }

--- a/lib/models/micro-addon.js
+++ b/lib/models/micro-addon.js
@@ -1,58 +1,100 @@
 'use strict';
 
+/**
+@module ember-cli
+*/
+
 var path = require('path');
 var existsSync   = require('exists-sync');
 var Funnel = require('broccoli-funnel');
+var assign       = require('lodash/object/assign');
+var SilentError  = require('silent-error');
+
 var Addon  = require('../models/addon');
 
-function getExistingFiles(fileList) {
-  return fileList.filter(function(file) {
-    return existsSync(file);
+function getExistingFiles(root, fileList) {
+  var filteredList = fileList.filter(function(file) {
+    return existsSync(path.join(root,file));
   });
+
+  return filteredList;
 }
 
-Addon.prototype.buildTree = function(sourceTree, includedFiles) {
-  var addon = this;
+var MicroAddon = Addon.extend({
 
-  return new Funnel(sourceTree, {
-    include: includedFiles,
-    getDestination: function(fileName) {
-      return addon.mapFile(fileName);
+  buildTree: function(sourceTree, includedFiles) {
+    var addon = this;
+
+    return new Funnel(sourceTree, {
+      include: includedFiles,
+      getDestinationPath: function(fileName) {
+        return addon.mapFile(fileName);
+      }
+    });
+  },
+
+  mapFile: function(fileName) {
+    if (fileName === 'component.js') {
+      return path.join('components', this.name + '.js');
+    } else if (fileName === 'template.hbs') {
+      return path.join('components', this.name + '.hbs');
+    } else if (fileName === 'style.css') {
+      return path.join('addon/styles', this.name + '.css');
+    } else if (fileName === 'helper.js') {
+      return path.join('helpers', this.name + '.js');
+    } else if (fileName === 'library.js') {
+      return path.join('lib', this.name + '.js');
     }
-  });
-};
+  },
 
-Addon.prototype.mapFile = function(fileName) {
-  if (fileName === 'component.js') {
-    return path.join('components', this.name + '.js');
-  } else if (fileName === 'template.hbs') {
-    return path.join('components', this.name + '.hbs');
-  } else if (fileName === 'style.css') {
-    return path.join('addon/styles', this.name + '.css');
-  } else if (fileName === 'helper.js') {
-    return path.join('helpers', this.name + '.js');
-  } else if (fileName === 'library.js') {
-    return path.join('lib', this.name + '.js');
+  treeForApp: function() {
+    var supportedFiles = ['component.js', 'helper.js', 'library.js'];
+    var includedFiles = getExistingFiles(this.root, supportedFiles);
+
+    return this.buildTree(this.root, includedFiles);
+  },
+
+  treeForTemplates: function() {
+    var supportedFiles = ['template.hbs'];
+    var includedFiles = getExistingFiles(this.root, supportedFiles);
+
+    return this.buildTree(this.root, includedFiles);
+  },
+
+  treeForAddon: function() {
+    var supportedFiles = ['style.css'];
+    var includedFiles = getExistingFiles(this.root, supportedFiles);
+
+    return this.buildTree(this.root, includedFiles);
   }
+});
+
+MicroAddon.lookup = function(addon) {
+  var Constructor, addonModule, modulePath, moduleDir;
+
+  modulePath = Addon.resolvePath(addon);
+  moduleDir  = path.dirname(modulePath);
+
+  if (existsSync(modulePath)) {
+    addonModule = require(modulePath);
+
+    if (typeof addonModule === 'function') {
+      Constructor = addonModule;
+      Constructor.prototype.root = Constructor.prototype.root || moduleDir;
+      Constructor.prototype.pkg  = Constructor.prototype.pkg || addon.pkg;
+    } else {
+      Constructor = MicroAddon.extend(assign({
+        root: moduleDir,
+        pkg: addon.pkg
+      }, addonModule));
+    }
+  }
+
+  if (!Constructor) {
+    throw new SilentError('The `' + addon.pkg.name + '` addon could not be found at `' + addon.path + '`.');
+  }
+
+  return Constructor;
 };
 
-Addon.prototype.treeForApp = function() {
-  var supportedFiles = ['component.js', 'helper.js', 'library.js'];
-  var includedFiles = getExistingFiles(supportedFiles);
-
-  return this.buildTree(this.root, includedFiles);
-};
-
-Addon.prototype.treeForTemplates = function() {
-  var supportedFiles = ['style.css'];
-  var includedFiles = getExistingFiles(supportedFiles);
-
-  return this.buildTree(this.root, includedFiles);
-};
-
-Addon.prototype.treeForAddon = function() {
-  var supportedFiles = ['template.hbs'];
-  var includedFiles = getExistingFiles(supportedFiles);
-
-  return this.buildTree(this.root, includedFiles);
-};
+module.exports = MicroAddon;

--- a/lib/models/micro-addon.js
+++ b/lib/models/micro-addon.js
@@ -1,8 +1,15 @@
 'use strict';
 
 var path = require('path');
+var existsSync   = require('exists-sync');
 var Funnel = require('broccoli-funnel');
 var Addon  = require('../models/addon');
+
+function getExistingFiles(fileList) {
+  return fileList.filter(function(file) {
+    return existsSync(file);
+  });
+}
 
 Addon.prototype.buildTree = function(sourceTree, includedFiles) {
   var addon = this;
@@ -24,17 +31,28 @@ Addon.prototype.mapFile = function(fileName) {
     return path.join('addon/styles', this.name + '.css');
   } else if (fileName === 'helper.js') {
     return path.join('helpers', this.name + '.js');
+  } else if (fileName === 'library.js') {
+    return path.join('lib', this.name + '.js');
   }
 };
 
 Addon.prototype.treeForApp = function() {
-  return this.buildTree(this.root, ['component.js', 'helper.js']);
+  var supportedFiles = ['component.js', 'helper.js', 'library.js'];
+  var includedFiles = getExistingFiles(supportedFiles);
+
+  return this.buildTree(this.root, includedFiles);
 };
 
 Addon.prototype.treeForTemplates = function() {
-  return this.buildTreew(this.root, ['style.css']);
+  var supportedFiles = ['style.css'];
+  var includedFiles = getExistingFiles(supportedFiles);
+
+  return this.buildTree(this.root, includedFiles);
 };
 
 Addon.prototype.treeForAddon = function() {
-  return this.buildTree(this.root, ['template.hbs']);
+  var supportedFiles = ['template.hbs'];
+  var includedFiles = getExistingFiles(supportedFiles);
+
+  return this.buildTree(this.root, includedFiles);
 };

--- a/lib/models/micro-addon.js
+++ b/lib/models/micro-addon.js
@@ -4,13 +4,13 @@
 @module ember-cli
 */
 
-var path = require('path');
-var existsSync   = require('exists-sync');
-var Funnel = require('broccoli-funnel');
-var assign       = require('lodash/object/assign');
-var SilentError  = require('silent-error');
+var path          = require('path');
+var existsSync    = require('exists-sync');
+var Funnel        = require('broccoli-funnel');
+var assign        = require('lodash/object/assign');
+var SilentError   = require('silent-error');
 
-var Addon  = require('../models/addon');
+var Addon         = require('../models/addon');
 
 function getExistingFiles(root, fileList) {
   var filteredList = fileList.filter(function(file) {
@@ -20,20 +20,66 @@ function getExistingFiles(root, fileList) {
   return filteredList;
 }
 
+/**
+  Root class for a Micro Addon. If your Addon module exports an Object, this
+  will be extended with that Object. If the addon module exports a constructor,
+  it will not be extending this vclass.
+
+  MicroAddon extends the base Addon class. The custom behavior of a Micro Addon
+  is implemented by defining some common hooks the Addon class exposes.
+
+  - {{#crosslink "MicroAddon/_buildTree:method"}}_buildTree{{/crosslink}}
+  - {{#crosslink "MicroAddon/_mapFile:method"}}_mapFile{{/crosslink}}
+  - {{#crosslink "MicroAddon/treeForApp:method"}}treeForApp{{/crosslink}}
+  - {{#crosslink "MicroAddon/treeForAddon:method"}}treeForAddon{{/crosslink}}
+  - {{#crosslink "MicroAddon/treeForTemplate:method"}}treeForTemplate{{/crosslink}}
+
+  @class MicroAddon
+  @extends Addon
+  @param {(Project|Addon)} parent The project or addon that directly depends on this addon
+  @param {Project} project The current project (deprecated)
+*/
 var MicroAddon = Addon.extend({
 
-  buildTree: function(sourceTree, includedFiles) {
+  /**
+    Builds a tree out of an explicit array of files
+
+    @private
+    @method _buildTree
+    @param {Array} includedFiles Array of filenames to build a tree from. All files are in addon root
+    @return {tree} Newly built tree
+  */
+  _buildTree: function(includedFiles) {
     var addon = this;
 
-    return new Funnel(sourceTree, {
+    return new Funnel(addon.root, {
       include: includedFiles,
       getDestinationPath: function(fileName) {
-        return addon.mapFile(fileName);
+        return addon._mapFile(fileName);
       }
     });
   },
 
-  mapFile: function(fileName) {
+  /**
+    Maps a source file (placed in addon root) to a destination file
+
+    Component mappings:
+    - component.js  -> components/addon-name.js
+    - template.hbs  -> templates/components/addon-name.hbs
+    - style.css     -> addon/styles/addon-name.css
+
+    Helper mappings:
+    - helper.js     -> helpers/addon-name.js
+
+    Library mappings:
+    - library.js    -> lib/addon-name.js
+
+    @private
+    @method _mapFile
+    @param {String} fileName Based file name
+    @return {String} Mapped file path
+  */
+  _mapFile: function(fileName) {
     if (fileName === 'component.js') {
       return path.join('components', this.name + '.js');
     } else if (fileName === 'template.hbs') {
@@ -47,28 +93,76 @@ var MicroAddon = Addon.extend({
     }
   },
 
+  /**
+    Maps app-related files from their location in a ember-micro-addon structure
+    to their proper place in an ember-addon structure.
+
+    Used by micro-components, micro-helpers and micro-libraries
+
+    @public
+    @method treeForApp
+    @return {tree} A tree with properly mapped files.
+  */
   treeForApp: function() {
     var supportedFiles = ['component.js', 'helper.js', 'library.js'];
     var includedFiles = getExistingFiles(this.root, supportedFiles);
 
-    return this.buildTree(this.root, includedFiles);
+    return this._buildTree(includedFiles);
   },
 
+  /**
+    Maps app-related files from their location in a ember-micro-addon structure
+    to their proper place in an ember-addon structure.
+
+    Used by micro-components
+
+    treeForTemplates maps to the templates subfolder automatically, so only the
+    components subfolder is necessary in the mapped path.
+
+    @public
+    @method treeForTemplates
+    @return {tree} A tree with properly mapped files.
+  */
   treeForTemplates: function() {
     var supportedFiles = ['template.hbs'];
     var includedFiles = getExistingFiles(this.root, supportedFiles);
 
-    return this.buildTree(this.root, includedFiles);
+    return this._buildTree(includedFiles);
   },
 
+  /**
+    Maps app-related files from their location in a ember-micro-addon structure
+    to their proper place in an ember-addon structure.
+
+    Used by micro-components
+
+    We use treeForAddon to make use of automatic style merging for any .css
+    files placed in the addon/styles folder
+
+    @public
+    @method treeForAddon
+    @return {tree} A tree with properly mapped files.
+  */
   treeForAddon: function() {
     var supportedFiles = ['style.css'];
     var includedFiles = getExistingFiles(this.root, supportedFiles);
 
-    return this.buildTree(this.root, includedFiles);
+    return this._buildTree(includedFiles);
   }
 });
 
+/**
+  Returns the micro-addon class for a given addon name.
+  If the MicroAddon exports a function, that function is used
+  as constructor. If an Object is exported, a subclass of
+  `MicroAddon` is returned with the exported hash merged into it.
+
+  @private
+  @static
+  @method lookup
+  @param {String} addon MicroAddon name
+  @return {MicroAddon} MicroAddon class
+*/
 MicroAddon.lookup = function(addon) {
   var Constructor, addonModule, modulePath, moduleDir;
 

--- a/tests/unit/models/micro-addon-test.js
+++ b/tests/unit/models/micro-addon-test.js
@@ -1,0 +1,107 @@
+'use strict';
+
+var path          = require('path');
+var Project       = require('../../../lib/models/project');
+var MicroAddon    = require('../../../lib/models/micro-addon');
+var expect        = require('chai').expect;
+var path          = require('path');
+
+var fixturePath   = path.resolve(__dirname, '../../fixtures/addon');
+
+describe('models/addon.js', function() {
+  var project, projectPath;
+
+  describe('treePaths and treeForMethods', function() {
+    var ExampleMicroAddon;
+
+    beforeEach(function() {
+      projectPath = path.resolve(fixturePath, 'simple');
+      var packageContents = require(path.join(projectPath, 'package.json'));
+
+      project = new Project(projectPath, packageContents);
+
+      ExampleMicroAddon = MicroAddon.extend({
+        name: 'example',
+        root: projectPath,
+      });
+    });
+
+    describe('treeForApp', function() {
+      it('exists even when not explicitly set', function() {
+        var first = new ExampleMicroAddon(project);
+
+        expect(first.treeForApp).to.be.a('Function');
+      });
+    });
+
+    describe('treeForAddon', function() {
+      it('exists even when not explicitly set', function() {
+        var first = new ExampleMicroAddon(project);
+
+        expect(first.treeForAddon).to.be.a('Function');
+      });
+    });
+
+    describe('treeForTemplates', function() {
+      it('exists even when not explicitly set', function() {
+        var first = new ExampleMicroAddon(project);
+
+        expect(first.treeForTemplates).to.be.a('Function');
+      });
+    });
+  });
+
+  describe('_buildTree', function() {
+    var ExampleMicroAddon;
+
+    beforeEach(function() {
+      projectPath = path.resolve(fixturePath, 'simple');
+      var packageContents = require(path.join(projectPath, 'package.json'));
+
+      project = new Project(projectPath, packageContents);
+
+      ExampleMicroAddon = MicroAddon.extend({
+        name: 'example',
+        root: projectPath,
+      });
+    });
+
+    it('should return a tree', function() {
+      var addon = new ExampleMicroAddon();
+
+      var tree = addon._buildTree(['component.js']);
+
+      expect(tree).to.contain.all.keys('inputTree', 'include', 'destDir', 'getDestinationPath');
+    });
+  });
+
+  describe('_mapFile', function() {
+    var ExampleMicroAddon, addon;
+
+    beforeEach(function() {
+      projectPath = path.resolve(fixturePath, 'simple');
+      var packageContents = require(path.join(projectPath, 'package.json'));
+
+      project = new Project(projectPath, packageContents);
+
+      ExampleMicroAddon = MicroAddon.extend({
+        name: 'example',
+        root: projectPath,
+      });
+
+      addon = new ExampleMicroAddon();
+    });
+
+    it('should perform the proper mapping', function() {
+      expect(addon._mapFile('component.js')).to.equal('components/example.js');
+      expect(addon._mapFile('helper.js')).to.equal('helpers/example.js');
+      expect(addon._mapFile('library.js')).to.equal('lib/example.js');
+      expect(addon._mapFile('template.hbs')).to.equal('components/example.hbs');
+      expect(addon._mapFile('style.css')).to.equal('addon/styles/example.css');
+    });
+
+    it('should return "undefined" for unsupported file', function() {
+      expect(addon._mapFile('random.ext')).to.equal(undefined);
+    });
+  });
+});


### PR DESCRIPTION
# Description

This is a temporary PR where we can keep the discussion and have an overview of changes before the micro addon feature is ready to be merged into ember-cli/ember-cli.

Once the feature is ready, we can delete this PR and create a new one against ember-cli/ember-cli#master
# ToDo
- [x] Clean up any potentially unnecessary stuff
- [x] Write tests
- [x] Write comments according to convention
- [x] Make sure the rest of the code is up to convention
- [ ] Write a proper PR description, to be used in the actual PR
# Final PR Description

This PR adds support to micro addons to ember-cli.
## Premise

The idea here is to enable usage of a type of ember addon in which the file structure is greatly simplified. Micro-components, micro-helpers and micro-libraries are supported within the current PR.

Using [coderly's CLI tool](https://github.com/coderly/ember-micro-addon), we are able to generate a micro-addon of a specific type with a single command.

```
ember-micro:<addon-type>
```

However, in order to be able to use such an addon out of the box, we are forced to have a modified `index.js` which uses `treeFor[Name]` hooks in order to make the addon compatible with an Ember-CLI app. Basically, the logic which makes a micro-addon work is exposed.

Making Ember-CLI support this feature internally would hide away this logic and open up the road for additional CLI tools.

For example, with another command, we can almost instantly publish the micro-addon to github:

```
ember-micro:publish <addonName>
```

It is also possible to extract a component, helper or library out of an existing app into a micro-addon. 

```
ember-micro:extract <addonType> <addonName> [-d|--destionation <destination>]
```

Finally, we have a command available which converts a micro-addon into a proper ember-addon

```
ember-micro:build <addonName>
```

The output is placed within `/addon-name/dist`.

The end result is a greatly simplified and sped up workflow. **We can create and publish a micro-addon in under 20 seconds, or extract part of an ember application into an addon just as quickly.**
## Implementation

The micro-addon files are organized in a completely flat file structure with the following files
- `package.json` for all addons. Needs to contain `ember-addon` as well as `ember-micro-addon` keywords
- `index.js` for all addons, Looks pretty much the same as `index.js` in a regular ember addon
- `component.js`, template.hbs`and`style.css` in the case of a micro-component
- `helper.js` in the case on a micro-helper
- `library.js` in the case of a micro-library

At build time, a micro-addon's files get renamed and moved so the micro-addon temporarily gets a proper addon structure. They are then available for import from the `app/components`, `app/helpers` or `addon/lib` namespace, depending on the type of addon.
